### PR TITLE
GameCube button combo for Xbox 360 Guide button

### DIFF
--- a/DelfinovinUI/Controller/ControllerSettings.cs
+++ b/DelfinovinUI/Controller/ControllerSettings.cs
@@ -20,6 +20,7 @@ namespace DelfinovinUI
 		public bool EnableRumble { get; set; } = false;
 		public bool SwapAB { get; set; } = true;
 		public bool SwapXY { get; set; } = true;
+		public bool GuideBTNCombo { get; set; } = true;
 
 		// A false value return from this method means that
 		// the file did not exist or did not contain any content.

--- a/DelfinovinUI/Controller/GamecubeController.cs
+++ b/DelfinovinUI/Controller/GamecubeController.cs
@@ -108,6 +108,7 @@ namespace DelfinovinUI
 				_controller.SetButtonState(Xbox360Button.Up, inputState.DPAD_UP);
 				_controller.SetButtonState(Xbox360Button.Down, inputState.DPAD_DOWN);
 				_controller.SetButtonState(Xbox360Button.Start, inputState.BUTTON_START);
+				_controller.SetButtonState(Xbox360Button.Guide, (Settings.GuideBTNCombo && inputState.DPAD_DOWN && inputState.BUTTON_START) ? true : false);
 
 				// Normalize values into triggerdeadzone/threshold range
 				byte clampedLeftTrigger = Extensions.ClampTriggers(inputState.ANALOG_LEFT, Settings.TriggerDeadzone, Settings.TriggerThreshold);

--- a/DelfinovinUI/MainWindow.xaml
+++ b/DelfinovinUI/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:DelfinovinUI" 
-        Title="MainWindow" Height="500" Width="830" WindowStyle="None" AllowsTransparency="True" FontFamily="Microsoft JhengHei Light" ResizeMode="NoResize">
+        Title="MainWindow" Height="550" Width="830" WindowStyle="None" AllowsTransparency="True" FontFamily="Microsoft JhengHei Light" ResizeMode="NoResize">
     
     <FrameworkElement.Resources>
         <ResourceDictionary>

--- a/DelfinovinUI/ProfileDialog.xaml.cs
+++ b/DelfinovinUI/ProfileDialog.xaml.cs
@@ -162,6 +162,7 @@ namespace DelfinovinUI
 				sb.AppendLine("Enable Rumble - " + ConvertYesNo(settings.EnableRumble));
 				sb.AppendLine("Swap A/B Buttons - " + ConvertYesNo(settings.SwapAB));
 				sb.AppendLine("Swap X/Y Buttons - " + ConvertYesNo(settings.SwapXY));
+				sb.AppendLine("Guide BTN Combo - " + ConvertYesNo(settings.GuideBTNCombo));
 				sb.AppendLine($"Trigger Deadzones - {settings.TriggerDeadzone * 100f}%");
 				sb.AppendLine($"Trigger Threshold - {settings.TriggerThreshold * 100f}%");
 				sb.AppendLine($"Left Stick Deadzones - {settings.LeftStickDeadzone * 100f}%");

--- a/DelfinovinUI/SettingsDialog.xaml
+++ b/DelfinovinUI/SettingsDialog.xaml
@@ -43,6 +43,7 @@
             <ListViewItem Content="Enable Digital Triggers" />
             <ListViewItem Content="SwapAB" />
             <ListViewItem Content="SwapXY" />
+            <ListViewItem Content="Guide BTN Combo" />
             <ListViewItem Content="TriggerDeadzone" />
             <ListViewItem Content="TriggerThreshold" />
             <ListViewItem Content="LeftStickDeadzone" />
@@ -63,6 +64,9 @@
             </ListViewItem>
             <ListViewItem>
                 <ToggleButton Name="swapXY" />
+            </ListViewItem>
+            <ListViewItem>
+                <ToggleButton Name="guideBTNCombo" />
             </ListViewItem>
             <ListViewItem>
                 <Slider Name="triggerDeadzone" Value="15" />

--- a/DelfinovinUI/SettingsDialog.xaml.cs
+++ b/DelfinovinUI/SettingsDialog.xaml.cs
@@ -27,6 +27,7 @@ namespace DelfinovinUI
 				RightStickRange = (float)(rightStickRange.Value / 100.0),
 				SwapAB = swapAB.IsChecked.Value,
 				SwapXY = swapXY.IsChecked.Value,
+				GuideBTNCombo = guideBTNCombo.IsChecked.Value,
 				TriggerDeadzone = (float)(triggerDeadzone.Value / 100.0),
 				TriggerThreshold = (float)(triggerThreshold.Value / 100.0)
 			};
@@ -43,6 +44,7 @@ namespace DelfinovinUI
 			rightStickRange.Value = controllerSettings.RightStickRange * 100f;
 			swapAB.IsChecked = controllerSettings.SwapAB;
 			swapXY.IsChecked = controllerSettings.SwapXY;
+			guideBTNCombo.IsChecked = controllerSettings.GuideBTNCombo;
 			triggerDeadzone.Value = controllerSettings.TriggerDeadzone * 100f;
 			triggerThreshold.Value = controllerSettings.TriggerThreshold * 100f;
 		}


### PR DESCRIPTION
Hello!

This is just an option to allow a key combo on the GC controller to map to the virtual 360 Controllers Guide button.
I set it to be dpad down + Start.
It's a comfortable combo to hit on a regular gamepad but wouldn't be usable on most dancepads and the DK bongos.  A+B+Start would work on pretty much every GameCube controller variant but would be slightly more awkward to use.

![Guide button combo](https://user-images.githubusercontent.com/32457340/152079963-2d319660-ae0f-427b-bd23-a1ccb9f0b5c9.png)
 